### PR TITLE
Workflows: use node version from .nvmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,14 @@ jobs:
       - name: Begin CI...
         uses: actions/checkout@v2
 
-      - name: Use Node 12
-        uses: actions/setup-node@v1
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+
+      - name: Use Node.js (.nvmrc)
+        uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
       - name: Use cached node_modules
         uses: actions/cache@v1
@@ -25,6 +29,7 @@ jobs:
           key: nodeModules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             nodeModules-
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         env:


### PR DESCRIPTION
- Making it consistent with the project node's version
- Fix the node version in the ci (project using v14, ci using v12)